### PR TITLE
Add version key to manifest.json

### DIFF
--- a/camect/manifest.json
+++ b/camect/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "camect",
   "name": "Camect",
+  "version": "0.1.10",
   "requirements": [
     "camect-py==0.1.10"
   ],


### PR DESCRIPTION
In Home Assistant 2021.6 and above, the version key is now required to load the component - see https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions

I copied the version number of camect-py as I couldn't see any versions for the component.