### PR TITLE
Update to meet new requirements for HA

### DIFF
--- a/camect/camera.py
+++ b/camect/camera.py
@@ -96,7 +96,7 @@ class Camera(camera.Camera):
         return self._home.snapshot_camera(self._device_id)
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return {
             'device_id': self._device_id,


### PR DESCRIPTION
As of 2021.12 release of HA, HA is warning integrations which use device_state_attributes to instead use extra_state_attributes. This change will meet that requirement.