### PR TITLE
Enable/Disable camera alerts

### DIFF
--- a/camect/__init__.py
+++ b/camect/__init__.py
@@ -25,6 +25,9 @@ DEFAULT_PORT = 8443
 DEFAULT_USERNAME = 'admin'
 DOMAIN = 'camect'
 SERVICE_CHANGE_OP_MODE = 'change_op_mode'
+SERVICE_DISABLE_CAMERA_ALERT = 'disable_camera_alert'
+SERVICE_ENABLE_CAMERA_ALERT = 'enable_camera_alert'
+CAMERA_IDS = 'camera'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema(vol.All([{
@@ -42,6 +45,10 @@ CHANGE_OP_MODE_SCHEMA = vol.Schema({
     vol.Required(ATTR_MODE): cv.string
 })
 
+CAMERA_ALERT_SCHEMA = vol.Schema({
+    vol.Required(CAMERA_IDS, default=[]): vol.All(
+        cv.ensure_list_csv, [cv.string])
+})
 
 def setup(hass, config):
     """Set up the Camect component."""
@@ -62,7 +69,7 @@ def setup(hass, config):
     discovery.load_platform(hass, camera.DOMAIN, DOMAIN, data, config)
 
 
-    # Register service.
+    # Register services.
     def handle_change_op_mode_service(call):
         mode = call.data.get(ATTR_MODE).upper()
         if mode in ('HOME', 'DEFAULT'):
@@ -73,4 +80,18 @@ def setup(hass, config):
         DOMAIN, SERVICE_CHANGE_OP_MODE, handle_change_op_mode_service,
         schema=CHANGE_OP_MODE_SCHEMA)
 
+    def handle_disable_camera_alert(call):
+        camera = call.data.get(CAMERA_IDS)
+        home.disable_alert(camera, "HomeAssistant")
+    hass.services.register(
+        DOMAIN, SERVICE_DISABLE_CAMERA_ALERT, handle_disable_camera_alert,
+        schema=CAMERA_ALERT_SCHEMA)
+
+    def handle_enable_camera_alert(call):
+        camera = call.data.get(CAMERA_IDS)
+        home.enable_alert(camera, "HomeAssistant")
+    hass.services.register(
+        DOMAIN, SERVICE_ENABLE_CAMERA_ALERT, handle_enable_camera_alert,
+        schema=CAMERA_ALERT_SCHEMA)
+    
     return True

--- a/camect/services.yaml
+++ b/camect/services.yaml
@@ -4,3 +4,15 @@ change_op_mode:
     mode:
       description: The new operation mode.
       example: home/away
+disable_camera_alert:
+  description: Disable camera(s).
+  fields:
+    camera:
+      description: ID of camera.
+      example: 0586c3143fd3db8b0149
+enable_camera_alert:
+  description: Enable camera(s).
+  fields:
+    camera:
+      description: ID of camera.
+      example: 0586c3143fd3db8b0149


### PR DESCRIPTION
This patch builds two new services `camect.enable_camera_alert` and `camect.disable_camera_alert` to enable/disable camera alerts and acts as an MVP (Minimally Viable Product) to meet the enhancement request [here](https://github.com/camect/home-assistant-integration/issues/7)