### PR TITLE
Override width and height values if HA requests them as "None".

### DIFF
--- a/camect/camera.py
+++ b/camect/camera.py
@@ -93,12 +93,12 @@ class Camera(camera.Camera):
 
     def camera_image(self, width = None, height = None) -> bytes:
         """Return a still image response from the camera."""
-        # The Camect library doesn't handle width or height being None so we force
-        # some arbitrary integer values if those params are set to that.
+        # The Camect library doesn't handle width or height being None so we override
+        # those parameters with the image dimensions previously reported by Camect
         if width is None:
-            width = 480
+            width = self._width
         if height is None:
-            height = 270
+            height = self._height
         return self._home.snapshot_camera(self._device_id, width, height)
 
     @property

--- a/camect/camera.py
+++ b/camect/camera.py
@@ -91,8 +91,14 @@ class Camera(camera.Camera):
         """Return a link to the camera feed as entity picture."""
         return None
 
-    def camera_image(self, width = None, height = None):
+    def camera_image(self, width = None, height = None) -> bytes:
         """Return a still image response from the camera."""
+        # The Camect library doesn't handle width or height being None so we force
+        # some arbitrary integer values if those params are set to that.
+        if width is None:
+            width = 480
+        if height is None:
+            height = 270
         return self._home.snapshot_camera(self._device_id, width, height)
 
     @property


### PR DESCRIPTION
This fixes the issue where you click a camera preview image from the Home (Lovelace) interface and get a broken image instead of a larger and (mostly) realtime camera preview.