### PR TITLE
set websockets requirement to <=13

### DIFF
--- a/camect/manifest.json
+++ b/camect/manifest.json
@@ -3,7 +3,8 @@
   "name": "Camect",
   "version": "0.1.10",
   "requirements": [
-    "camect-py==0.1.10"
+    "camect-py==0.1.10",
+    "websockets<=13"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
websockets 14 changes some argument names and will require matching changes in the camect module (see: https://github.com/camect/camect-py/issues/20)